### PR TITLE
Allow 3 way logic evaluation via datastore hint. Centralized test execution code

### DIFF
--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCFeatureSource.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCFeatureSource.java
@@ -67,6 +67,17 @@ import org.locationtech.jts.geom.Geometry;
 
 public class JDBCFeatureSource extends ContentFeatureSource {
 
+    /**
+     * Add this hint to the query to force the filter to be interepreted as a three-way logic
+     * filter, where null values are treated as unknowns and propagate up the filter evaluation tree
+     * (e..g, <code>A <> NULL -> NULL</code>)</>. By default, the encoding is performed using
+     * two-way logic, where null values are treated as legitimate values (like <code>null</code> in
+     * Java). Also, warning: the hint cannot be provided to {@link
+     * org.geotools.api.data.FeatureStore#removeFeatures(Filter)} as that only gets a {@link Filter}
+     * object, rather than a query object.
+     */
+    public static final Hints.Key FILTER_THREE_WAY_LOGIC = new Hints.Key(Boolean.class);
+
     private static final Logger LOGGER = Logging.getLogger(JDBCFeatureSource.class);
     private static final String REMARKS = "REMARKS";
 
@@ -384,10 +395,14 @@ public class JDBCFeatureSource extends ContentFeatureSource {
 
     /** Helper method for splitting a filter. */
     protected Filter[] splitFilter(Filter original) {
-        return splitFilter(original, this);
+        return splitFilter(original, this, null);
     }
 
-    Filter[] splitFilter(Filter original, FeatureSource source) {
+    protected Filter[] splitFilter(Filter original, Hints hints) {
+        return splitFilter(original, this, hints);
+    }
+
+    static Filter[] splitFilter(Filter original, FeatureSource source, Hints hints) {
         JDBCFeatureSource featureSource = null;
         if (source instanceof JDBCFeatureSource) {
             featureSource = (JDBCFeatureSource) source;
@@ -397,17 +412,20 @@ public class JDBCFeatureSource extends ContentFeatureSource {
 
         Filter[] split = new Filter[2];
         if (original != null) {
-            split = getDataStore().getSQLDialect().splitFilter(original, featureSource.getSchema());
+            JDBCDataStore dataStore = (JDBCDataStore) source.getDataStore();
+            split = dataStore.getSQLDialect().splitFilter(original, featureSource.getSchema());
         }
 
         // handle three-valued logic differences by adding "is not null" checks in the filter,
         // the simplifying filter visitor will take care of them if they are redundant
-        NullHandlingVisitor nhv = new NullHandlingVisitor(source.getSchema());
-        split[0] = (Filter) split[0].accept(nhv, null);
+        if (hints == null || !Boolean.TRUE.equals(hints.get(FILTER_THREE_WAY_LOGIC))) {
+            NullHandlingVisitor nhv = new NullHandlingVisitor(source.getSchema());
+            split[0] = (Filter) split[0].accept(nhv, null);
+        }
 
         SimplifyingFilterVisitor visitor = new SimplifyingFilterVisitor();
         visitor.setFIDValidator(new PrimaryKeyFIDValidator(featureSource));
-        visitor.setFeatureType(getSchema());
+        visitor.setFeatureType(source.getSchema());
         split[0] = (Filter) split[0].accept(visitor, null);
         split[1] = (Filter) split[1].accept(visitor, null);
 
@@ -419,7 +437,7 @@ public class JDBCFeatureSource extends ContentFeatureSource {
         JDBCDataStore store = getDataStore();
 
         // split the filter
-        Filter[] split = splitFilter(query.getFilter());
+        Filter[] split = splitFilter(query.getFilter(), query.getHints());
         Filter preFilter = split[0];
         Filter postFilter = split[1];
 
@@ -485,7 +503,7 @@ public class JDBCFeatureSource extends ContentFeatureSource {
         JDBCDataStore dataStore = getDataStore();
 
         // split the filter
-        Filter[] split = splitFilter(query.getFilter());
+        Filter[] split = splitFilter(query.getFilter(), query.getHints());
         Filter preFilter = split[0];
         Filter postFilter = split[1];
 
@@ -572,7 +590,7 @@ public class JDBCFeatureSource extends ContentFeatureSource {
     protected FeatureReader<SimpleFeatureType, SimpleFeature> getReaderInternal(Query query)
             throws IOException {
         // split the filter
-        Filter[] split = splitFilter(query.getFilter());
+        Filter[] split = splitFilter(query.getFilter(), query.getHints());
         Filter preFilter = split[0];
         Filter postFilter = split[1];
         boolean postFilterRequired = postFilter != null && postFilter != Filter.INCLUDE;

--- a/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCFeatureStore.java
+++ b/modules/library/jdbc/src/main/java/org/geotools/jdbc/JDBCFeatureStore.java
@@ -276,7 +276,7 @@ public final class JDBCFeatureStore extends ContentFeatureStore {
             }
 
             // split the filter
-            Filter[] split = delegate.splitFilter(query.getFilter());
+            Filter[] split = delegate.splitFilter(query.getFilter(), query.getHints());
             Filter preFilter = split[0];
             postFilter = split[1];
 
@@ -335,7 +335,8 @@ public final class JDBCFeatureStore extends ContentFeatureStore {
         }
 
         // split the filter
-        Filter[] splitted = delegate.splitFilter(filter);
+        Filter[] splitted =
+                delegate.splitFilter(filter, this.query != null ? this.query.getHints() : null);
         Filter preFilter = splitted[0];
         Filter postFilter = splitted[1];
 
@@ -398,7 +399,8 @@ public final class JDBCFeatureStore extends ContentFeatureStore {
 
     @Override
     public void removeFeatures(Filter filter) throws IOException {
-        Filter[] splitted = delegate.splitFilter(filter);
+        Filter[] splitted =
+                delegate.splitFilter(filter, this.query != null ? this.query.getHints() : null);
         Filter preFilter = splitted[0];
         Filter postFilter = splitted[1];
 

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCThreeValuedLogicOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCThreeValuedLogicOnlineTest.java
@@ -13,6 +13,10 @@ import org.geotools.data.store.ContentFeatureSource;
 import org.geotools.factory.CommonFactoryFinder;
 import org.junit.Test;
 
+/**
+ * Checks that the filters are converted to two-value logic, unless the {@link
+ * JDBCFeatureSource#FILTER_THREE_WAY_LOGIC} hint is enabled
+ */
 public abstract class JDBCThreeValuedLogicOnlineTest extends JDBCTestSupport {
 
     protected static final String ABC = "abc";
@@ -32,6 +36,22 @@ public abstract class JDBCThreeValuedLogicOnlineTest extends JDBCTestSupport {
         ContentFeatureSource fs = dataStore.getFeatureSource(tname(ABC));
         int count = fs.getCount(new Query(tname(ABC), filter));
         assertEquals(2, count);
+    }
+
+    /**
+     * Allow full 3 way logic, ABC has a row where A is null, won't be matched by <code>not(A = 10)
+     * </code> because <code>not(null = 10) -> null</code>
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSimpleNegatione3way() throws Exception {
+        Not filter = ff.not(ff.equal(ff.property(aname(A)), ff.literal(10), false));
+        ContentFeatureSource fs = dataStore.getFeatureSource(tname(ABC));
+        Query query = new Query(tname(ABC), filter);
+        query.getHints().put(JDBCFeatureSource.FILTER_THREE_WAY_LOGIC, true);
+        int count = fs.getCount(query);
+        assertEquals(1, count);
     }
 
     @Test

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCThreeValuedLogicTestSetup.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCThreeValuedLogicTestSetup.java
@@ -29,8 +29,11 @@ public class JDBCThreeValuedLogicTestSetup extends JDBCDelegatingTestSetup {
      *
      * <p>abc( name: string; a : integer; b : integer; c : integer)
      *
-     * <p>The table should be populated with the following data n_n_n | null | null | null a_b_c | 1
-     * | 2 | 3 Where [0,1,2,3,4,5] is a byte[]
+     * <p>The table should be populated with the following data <code>
+     * n_n_n | null | null | null
+     * a_b_c | 1 | 2 | 3
+     * </code><br>
+     * Where [0,1,2,3,4,5] is a byte[]
      */
     protected void createAbcTable() throws Exception {
         run("CREATE TABLE \"abc\"(\"name\" varchar(10), \"a\" int, \"b\" int, \"c\" int)");

--- a/modules/unsupported/cql2-json/src/test/java/org/geotools/filter/text/cqljson/conformance/ConformanceTest13OnlineTest.java
+++ b/modules/unsupported/cql2-json/src/test/java/org/geotools/filter/text/cqljson/conformance/ConformanceTest13OnlineTest.java
@@ -17,26 +17,27 @@
 
 package org.geotools.filter.text.cqljson.conformance;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import org.geotools.api.data.DataStore;
 import org.geotools.api.filter.Filter;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.filter.text.cqljson.CQL2Json;
-import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 /**
  * See <a href="https://docs.ogc.org/is/21-065r2/21-065r2.html#_conformance_test_13">table 9 from
  * section A.4.4 Conformance test 13.</a>
  */
-@RunWith(Parameterized.class)
 public class ConformanceTest13OnlineTest
         extends org.geotools.filter.text.cql_2.conformance.ConformanceTest13OnlineTest {
 
-    public ConformanceTest13OnlineTest(String criteria, int expectedFeatures) {
+    public ConformanceTest13OnlineTest(String criteria, int expectedFeatures) throws CQLException {
         super(criteria, expectedFeatures);
+    }
+
+    @Override
+    protected Filter criteriaToFilter(String criteria) throws CQLException {
+        return CQL2Json.toFilter(criteria);
     }
 
     @Parameterized.Parameters(name = "{index} {0}")
@@ -94,11 +95,5 @@ public class ConformanceTest13OnlineTest
                         2
                     }
                 });
-    }
-
-    @Override
-    protected int featuresReturned(DataStore ds) throws CQLException, IOException {
-        Filter filter = CQL2Json.toFilter(this.criteria);
-        return ds.getFeatureSource("ne_110m_populated_places_simple").getFeatures(filter).size();
     }
 }

--- a/modules/unsupported/cql2-json/src/test/java/org/geotools/filter/text/cqljson/conformance/ConformanceTest26OnlineTest.java
+++ b/modules/unsupported/cql2-json/src/test/java/org/geotools/filter/text/cqljson/conformance/ConformanceTest26OnlineTest.java
@@ -17,10 +17,8 @@
 
 package org.geotools.filter.text.cqljson.conformance;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import org.geotools.api.data.DataStore;
 import org.geotools.api.filter.Filter;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.filter.text.cqljson.CQL2Json;
@@ -35,8 +33,14 @@ import org.junit.runners.Parameterized;
 public class ConformanceTest26OnlineTest
         extends org.geotools.filter.text.cql_2.conformance.ConformanceTest26OnlineTest {
 
-    public ConformanceTest26OnlineTest(String dataset, String criteria, int expectedFeatures) {
+    public ConformanceTest26OnlineTest(String dataset, String criteria, int expectedFeatures)
+            throws CQLException {
         super(dataset, criteria, expectedFeatures);
+    }
+
+    @Override
+    protected Filter criteriaToFilter(String criteria) throws CQLException {
+        return CQL2Json.toFilter(criteria);
     }
 
     @Parameterized.Parameters(name = "{index} {0} {1}")
@@ -84,11 +88,5 @@ public class ConformanceTest26OnlineTest
                         4
                     }
                 });
-    }
-
-    @Override
-    protected int featuresReturned(DataStore ds) throws CQLException, IOException {
-        Filter filter = CQL2Json.toFilter(this.criteria);
-        return ds.getFeatureSource(this.dataset).getFeatures(filter).size();
     }
 }

--- a/modules/unsupported/cql2-json/src/test/java/org/geotools/filter/text/cqljson/conformance/ConformanceTest29OnlineTest.java
+++ b/modules/unsupported/cql2-json/src/test/java/org/geotools/filter/text/cqljson/conformance/ConformanceTest29OnlineTest.java
@@ -17,26 +17,27 @@
 
 package org.geotools.filter.text.cqljson.conformance;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import org.geotools.api.data.DataStore;
 import org.geotools.api.filter.Filter;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.filter.text.cqljson.CQL2Json;
-import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 /**
  * See <a href="https://docs.ogc.org/is/21-065r2/21-065r2.html#_conformance_test_29">table 13 from
  * section A.8.2 Conformance test 29.</a>
  */
-@RunWith(Parameterized.class)
 public class ConformanceTest29OnlineTest
         extends org.geotools.filter.text.cql_2.conformance.ConformanceTest29OnlineTest {
 
-    public ConformanceTest29OnlineTest(String criteria, int expectedFeatures) {
+    public ConformanceTest29OnlineTest(String criteria, int expectedFeatures) throws CQLException {
         super(criteria, expectedFeatures);
+    }
+
+    @Override
+    protected Filter criteriaToFilter(String criteria) throws CQLException {
+        return CQL2Json.toFilter(criteria);
     }
 
     @Parameterized.Parameters(name = "{index} {0} {1}")
@@ -72,11 +73,5 @@ public class ConformanceTest29OnlineTest
                         3
                     }
                 });
-    }
-
-    @Override
-    protected int featuresReturned(DataStore ds) throws CQLException, IOException {
-        Filter filter = CQL2Json.toFilter(this.criteria);
-        return ds.getFeatureSource("ne_110m_admin_0_countries").getFeatures(filter).size();
     }
 }

--- a/modules/unsupported/cql2-json/src/test/java/org/geotools/filter/text/cqljson/conformance/ConformanceTest38OnlineTest.java
+++ b/modules/unsupported/cql2-json/src/test/java/org/geotools/filter/text/cqljson/conformance/ConformanceTest38OnlineTest.java
@@ -17,26 +17,28 @@
 
 package org.geotools.filter.text.cqljson.conformance;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import org.geotools.api.data.DataStore;
 import org.geotools.api.filter.Filter;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.filter.text.cqljson.CQL2Json;
-import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 /**
  * See <a href="https://docs.ogc.org/is/21-065r2/21-065r2.html#_conformance_test_38">table 14 from
  * section A.9.9 Conformance test 38.</a>
  */
-@RunWith(Parameterized.class)
 public class ConformanceTest38OnlineTest
         extends org.geotools.filter.text.cql_2.conformance.ConformanceTest38OnlineTest {
 
-    public ConformanceTest38OnlineTest(String dataset, String criteria, int expectedFeatures) {
+    public ConformanceTest38OnlineTest(String dataset, String criteria, int expectedFeatures)
+            throws CQLException {
         super(dataset, criteria, expectedFeatures);
+    }
+
+    @Override
+    protected Filter criteriaToFilter(String criteria) throws CQLException {
+        return CQL2Json.toFilter(criteria);
     }
 
     @Parameterized.Parameters(name = "{index} {0} {1}")
@@ -174,11 +176,5 @@ public class ConformanceTest38OnlineTest
                         11
                     }
                 });
-    }
-
-    @Override
-    protected int featuresReturned(DataStore ds) throws CQLException, IOException {
-        Filter filter = CQL2Json.toFilter(this.criteria);
-        return ds.getFeatureSource(this.dataset).getFeatures(filter).size();
     }
 }

--- a/modules/unsupported/cql2-json/src/test/java/org/geotools/filter/text/cqljson/conformance/ConformanceTest42OnlineTest.java
+++ b/modules/unsupported/cql2-json/src/test/java/org/geotools/filter/text/cqljson/conformance/ConformanceTest42OnlineTest.java
@@ -17,26 +17,27 @@
 
 package org.geotools.filter.text.cqljson.conformance;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import org.geotools.api.data.DataStore;
 import org.geotools.api.filter.Filter;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.filter.text.cqljson.CQL2Json;
-import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 /**
  * See <a href="https://docs.ogc.org/is/21-065r2/21-065r2.html#_conformance_test_42">table 15 from
  * section A.10.3 Conformance test 42.</a>
  */
-@RunWith(Parameterized.class)
 public class ConformanceTest42OnlineTest
         extends org.geotools.filter.text.cql_2.conformance.ConformanceTest42OnlineTest {
 
-    public ConformanceTest42OnlineTest(String criteria, int expectedFeatures) {
+    public ConformanceTest42OnlineTest(String criteria, int expectedFeatures) throws CQLException {
         super(criteria, expectedFeatures);
+    }
+
+    @Override
+    protected Filter criteriaToFilter(String criteria) throws CQLException {
+        return CQL2Json.toFilter(criteria);
     }
 
     @Parameterized.Parameters(name = "{index} {0} {1}")
@@ -98,11 +99,5 @@ public class ConformanceTest42OnlineTest
                     {"{}", 1}, // TODO broken text filter, cannot be converted to json
                     {"{}", 0} // TODO broken text filter, cannot be converted to json
                 });
-    }
-
-    @Override
-    protected int featuresReturned(DataStore ds) throws CQLException, IOException {
-        Filter filter = CQL2Json.toFilter(this.criteria);
-        return ds.getFeatureSource("ne_110m_populated_places_simple").getFeatures(filter).size();
     }
 }

--- a/modules/unsupported/cql2-json/src/test/java/org/geotools/filter/text/cqljson/conformance/ConformanceTest49OnlineTest.java
+++ b/modules/unsupported/cql2-json/src/test/java/org/geotools/filter/text/cqljson/conformance/ConformanceTest49OnlineTest.java
@@ -17,26 +17,28 @@
 
 package org.geotools.filter.text.cqljson.conformance;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import org.geotools.api.data.DataStore;
 import org.geotools.api.filter.Filter;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.filter.text.cqljson.CQL2Json;
-import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 /**
  * See <a href="https://docs.ogc.org/is/21-065r2/21-065r2.html#_conformance_test_49">table 16 from
  * section A.12.4 Conformance test 49.</a>
  */
-@RunWith(Parameterized.class)
 public class ConformanceTest49OnlineTest
         extends org.geotools.filter.text.cql_2.conformance.ConformanceTest49OnlineTest {
 
-    public ConformanceTest49OnlineTest(String dataset, String criteria, int feat) {
+    public ConformanceTest49OnlineTest(String dataset, String criteria, int feat)
+            throws CQLException {
         super(dataset, criteria, feat);
+    }
+
+    @Override
+    protected Filter criteriaToFilter(String criteria) throws CQLException {
+        return CQL2Json.toFilter(criteria);
     }
 
     @Parameterized.Parameters(name = "{index} {0} {1}")
@@ -489,11 +491,5 @@ public class ConformanceTest49OnlineTest
                         "ne_110m_populated_places_simple", "{}", 1
                     } // TODO text filter cannot be parsed nor translated into JSON
                 });
-    }
-
-    @Override
-    protected int featuresReturned(DataStore ds) throws CQLException, IOException {
-        Filter filter = CQL2Json.toFilter(this.criteria);
-        return ds.getFeatureSource(this.dataset).getFeatures(filter).size();
     }
 }

--- a/modules/unsupported/cql2-json/src/test/java/org/geotools/filter/text/cqljson/conformance/ConformanceTest53OnlineTest.java
+++ b/modules/unsupported/cql2-json/src/test/java/org/geotools/filter/text/cqljson/conformance/ConformanceTest53OnlineTest.java
@@ -17,26 +17,27 @@
 
 package org.geotools.filter.text.cqljson.conformance;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import org.geotools.api.data.DataStore;
 import org.geotools.api.filter.Filter;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.filter.text.cqljson.CQL2Json;
-import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 /**
  * See <a href="https://docs.ogc.org/is/21-065r2/21-065r2.html#_conformance_test_53">table 17 from
  * section A.14.2 Conformance test 53.</a>
  */
-@RunWith(Parameterized.class)
 public class ConformanceTest53OnlineTest
         extends org.geotools.filter.text.cql_2.conformance.ConformanceTest53OnlineTest {
 
-    public ConformanceTest53OnlineTest(String criteria, int feat) {
+    public ConformanceTest53OnlineTest(String criteria, int feat) throws CQLException {
         super(criteria, feat);
+    }
+
+    @Override
+    protected Filter criteriaToFilter(String criteria) throws CQLException {
+        return CQL2Json.toFilter(criteria);
     }
 
     @Parameterized.Parameters(name = "{index} {0} {1}")
@@ -81,11 +82,5 @@ public class ConformanceTest53OnlineTest
                         1
                     }
                 });
-    }
-
-    @Override
-    protected int featuresReturned(DataStore ds) throws CQLException, IOException {
-        Filter filter = CQL2Json.toFilter(this.criteria);
-        return ds.getFeatureSource("ne_110m_populated_places_simple").getFeatures(filter).size();
     }
 }

--- a/modules/unsupported/cql2-json/src/test/java/org/geotools/filter/text/cqljson/conformance/ConformanceTest8OnlineTest.java
+++ b/modules/unsupported/cql2-json/src/test/java/org/geotools/filter/text/cqljson/conformance/ConformanceTest8OnlineTest.java
@@ -17,26 +17,28 @@
 
 package org.geotools.filter.text.cqljson.conformance;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import org.geotools.api.data.DataStore;
 import org.geotools.api.filter.Filter;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.filter.text.cqljson.CQL2Json;
-import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 /**
  * See <a href="https://docs.ogc.org/is/21-065r2/21-065r2.html#_conformance_test_8">table 7 from
  * section A.3.5 Conformance test 8.</a>
  */
-@RunWith(Parameterized.class)
 public class ConformanceTest8OnlineTest
         extends org.geotools.filter.text.cql_2.conformance.ConformanceTest8OnlineTest {
 
-    public ConformanceTest8OnlineTest(String dataset, String criteria, int expectedFeatures) {
+    public ConformanceTest8OnlineTest(String dataset, String criteria, int expectedFeatures)
+            throws CQLException {
         super(dataset, criteria, expectedFeatures);
+    }
+
+    @Override
+    protected Filter criteriaToFilter(String criteria) throws CQLException {
+        return CQL2Json.toFilter(criteria);
     }
 
     @Parameterized.Parameters(name = "{index} {0} {1}")
@@ -284,11 +286,5 @@ public class ConformanceTest8OnlineTest
                         1
                     }
                 });
-    }
-
-    @Override
-    protected int featuresReturned(DataStore ds) throws CQLException, IOException {
-        Filter filter = CQL2Json.toFilter(this.criteria);
-        return ds.getFeatureSource(this.dataset).getFeatures(filter).size();
     }
 }

--- a/modules/unsupported/cql2-json/src/test/java/org/geotools/filter/text/cqljson/conformance/ConformanceTest9OnlineTest.java
+++ b/modules/unsupported/cql2-json/src/test/java/org/geotools/filter/text/cqljson/conformance/ConformanceTest9OnlineTest.java
@@ -17,31 +17,22 @@
 
 package org.geotools.filter.text.cqljson.conformance;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import org.geotools.api.data.DataStore;
-import org.geotools.api.filter.Filter;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.filter.text.cqljson.CQL2Json;
-import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 /**
  * See <a href="https://docs.ogc.org/is/21-065r2/21-065r2.html#_conformance_test_9">table 8 from
  * section A.3.6 Conformance test 9.</a>
  */
-@RunWith(Parameterized.class)
 public class ConformanceTest9OnlineTest
         extends org.geotools.filter.text.cql_2.conformance.ConformanceTest9OnlineTest {
 
-    private final String jsonCriteria;
-
-    public ConformanceTest9OnlineTest(String jsonCriteria, int expectedFeatures) {
-        // We need to call super() but we won't use the criterias from the mother class
-        // for this one.
-        super(null, null, null, null, expectedFeatures);
-        this.jsonCriteria = jsonCriteria;
+    public ConformanceTest9OnlineTest(String jsonCriteria, int expectedFeatures)
+            throws CQLException {
+        super(CQL2Json.toFilter(jsonCriteria), expectedFeatures);
     }
 
     @Parameterized.Parameters(name = "{index}")
@@ -358,11 +349,5 @@ public class ConformanceTest9OnlineTest
                         44
                     }
                 });
-    }
-
-    @Override
-    protected int featuresReturned(DataStore ds) throws CQLException, IOException {
-        Filter filter = CQL2Json.toFilter(this.jsonCriteria);
-        return ds.getFeatureSource("ne_110m_populated_places_simple").getFeatures(filter).size();
     }
 }

--- a/modules/unsupported/cql2-text/src/test/java/org/geotools/filter/text/cql_2/conformance/ConformanceTest13OnlineTest.java
+++ b/modules/unsupported/cql2-text/src/test/java/org/geotools/filter/text/cql_2/conformance/ConformanceTest13OnlineTest.java
@@ -17,16 +17,9 @@
 
 package org.geotools.filter.text.cql_2.conformance;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import org.geootols.filter.text.cql_2.CQL2;
-import org.geotools.api.data.DataStore;
-import org.geotools.api.filter.Filter;
 import org.geotools.filter.text.cql2.CQLException;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -37,12 +30,8 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class ConformanceTest13OnlineTest extends ATSOnlineTest {
 
-    protected final String criteria;
-    protected final int expectedFeatures;
-
-    public ConformanceTest13OnlineTest(String criteria, int expectedFeatures) {
-        this.criteria = criteria;
-        this.expectedFeatures = expectedFeatures;
+    public ConformanceTest13OnlineTest(String criteria, int expectedFeatures) throws CQLException {
+        super("ne_110m_populated_places_simple", criteria, expectedFeatures);
     }
 
     @Parameterized.Parameters(name = "{index} {0}")
@@ -67,19 +56,5 @@ public class ConformanceTest13OnlineTest extends ATSOnlineTest {
                     {"boolean in (true)", 2},
                     {"boolean not in (false)", 2}
                 });
-    }
-
-    public @Test void testConformance() throws IOException, CQLException {
-        DataStore ds = naturalEarthData();
-        int feat = featuresReturned(ds);
-        ds.dispose();
-
-        assertEquals(this.expectedFeatures, feat);
-    }
-
-    protected int featuresReturned(DataStore ds) throws CQLException, IOException {
-        Filter filter = CQL2.toFilter(this.criteria);
-
-        return ds.getFeatureSource("ne_110m_populated_places_simple").getFeatures(filter).size();
     }
 }

--- a/modules/unsupported/cql2-text/src/test/java/org/geotools/filter/text/cql_2/conformance/ConformanceTest26OnlineTest.java
+++ b/modules/unsupported/cql2-text/src/test/java/org/geotools/filter/text/cql_2/conformance/ConformanceTest26OnlineTest.java
@@ -17,16 +17,9 @@
 
 package org.geotools.filter.text.cql_2.conformance;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import org.geootols.filter.text.cql_2.CQL2;
-import org.geotools.api.data.DataStore;
-import org.geotools.api.filter.Filter;
 import org.geotools.filter.text.cql2.CQLException;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -37,14 +30,9 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class ConformanceTest26OnlineTest extends ATSOnlineTest {
 
-    protected final String dataset;
-    protected final String criteria;
-    protected final int expectedFeatures;
-
-    public ConformanceTest26OnlineTest(String dataset, String criteria, int expectedFeatures) {
-        this.dataset = dataset;
-        this.criteria = criteria;
-        this.expectedFeatures = expectedFeatures;
+    public ConformanceTest26OnlineTest(String dataset, String criteria, int expectedFeatures)
+            throws CQLException {
+        super(dataset, criteria, expectedFeatures);
     }
 
     @Parameterized.Parameters(name = "{index} {0} {1}")
@@ -72,18 +60,5 @@ public class ConformanceTest26OnlineTest extends ATSOnlineTest {
                     {"ne_110m_populated_places_simple", "S_INTERSECTS(geom,BBOX(0,40,10,50))", 7},
                     {"ne_110m_rivers_lake_centerlines", "S_INTERSECTS(geom,BBOX(-180,-90,0,90))", 4}
                 });
-    }
-
-    public @Test void testConformance() throws CQLException, IOException {
-        DataStore ds = naturalEarthData();
-        int feat = featuresReturned(ds);
-        ds.dispose();
-
-        assertEquals(this.expectedFeatures, feat);
-    }
-
-    protected int featuresReturned(DataStore ds) throws CQLException, IOException {
-        Filter filter = CQL2.toFilter(this.criteria);
-        return ds.getFeatureSource(this.dataset).getFeatures(filter).size();
     }
 }

--- a/modules/unsupported/cql2-text/src/test/java/org/geotools/filter/text/cql_2/conformance/ConformanceTest29OnlineTest.java
+++ b/modules/unsupported/cql2-text/src/test/java/org/geotools/filter/text/cql_2/conformance/ConformanceTest29OnlineTest.java
@@ -17,16 +17,9 @@
 
 package org.geotools.filter.text.cql_2.conformance;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import org.geootols.filter.text.cql_2.CQL2;
-import org.geotools.api.data.DataStore;
-import org.geotools.api.filter.Filter;
 import org.geotools.filter.text.cql2.CQLException;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -37,12 +30,8 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class ConformanceTest29OnlineTest extends ATSOnlineTest {
 
-    protected final String criteria;
-    protected final int expectedFeatures;
-
-    public ConformanceTest29OnlineTest(String criteria, int expectedFeatures) {
-        this.criteria = criteria;
-        this.expectedFeatures = expectedFeatures;
+    public ConformanceTest29OnlineTest(String criteria, int expectedFeatures) throws CQLException {
+        super("ne_110m_admin_0_countries", criteria, expectedFeatures);
     }
 
     @Parameterized.Parameters(name = "{index} {0} {1}")
@@ -72,18 +61,5 @@ public class ConformanceTest29OnlineTest extends ATSOnlineTest {
                         3
                     }
                 });
-    }
-
-    public @Test void testConformance() throws CQLException, IOException {
-        DataStore ds = naturalEarthData();
-        int feat = featuresReturned(ds);
-        ds.dispose();
-
-        assertEquals(this.expectedFeatures, feat);
-    }
-
-    protected int featuresReturned(DataStore ds) throws CQLException, IOException {
-        Filter filter = CQL2.toFilter(this.criteria);
-        return ds.getFeatureSource("ne_110m_admin_0_countries").getFeatures(filter).size();
     }
 }

--- a/modules/unsupported/cql2-text/src/test/java/org/geotools/filter/text/cql_2/conformance/ConformanceTest38OnlineTest.java
+++ b/modules/unsupported/cql2-text/src/test/java/org/geotools/filter/text/cql_2/conformance/ConformanceTest38OnlineTest.java
@@ -17,16 +17,9 @@
 
 package org.geotools.filter.text.cql_2.conformance;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import org.geootols.filter.text.cql_2.CQL2;
-import org.geotools.api.data.DataStore;
-import org.geotools.api.filter.Filter;
 import org.geotools.filter.text.cql2.CQLException;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -37,14 +30,9 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class ConformanceTest38OnlineTest extends ATSOnlineTest {
 
-    protected final String dataset;
-    protected final String criteria;
-    protected final int expectedFeatures;
-
-    public ConformanceTest38OnlineTest(String dataset, String criteria, int expectedFeatures) {
-        this.dataset = dataset;
-        this.criteria = criteria;
-        this.expectedFeatures = expectedFeatures;
+    public ConformanceTest38OnlineTest(String dataset, String criteria, int expectedFeatures)
+            throws CQLException {
+        super(dataset, criteria, expectedFeatures);
     }
 
     @Parameterized.Parameters(name = "{index} {0} {1}")
@@ -126,18 +114,5 @@ public class ConformanceTest38OnlineTest extends ATSOnlineTest {
                     {"ne_110m_admin_0_countries", "S_CONTAINS(geom,POINT(7.02 49.92))", 1},
                     {"ne_110m_admin_0_countries", "S_OVERLAPS(geom,BBOX(-180,-90,0,90))", 11}
                 });
-    }
-
-    public @Test void testConformance() throws CQLException, IOException {
-        DataStore ds = naturalEarthData();
-        int feat = featuresReturned(ds);
-        ds.dispose();
-
-        assertEquals(this.expectedFeatures, feat);
-    }
-
-    protected int featuresReturned(DataStore ds) throws CQLException, IOException {
-        Filter filter = CQL2.toFilter(this.criteria);
-        return ds.getFeatureSource(this.dataset).getFeatures(filter).size();
     }
 }

--- a/modules/unsupported/cql2-text/src/test/java/org/geotools/filter/text/cql_2/conformance/ConformanceTest42OnlineTest.java
+++ b/modules/unsupported/cql2-text/src/test/java/org/geotools/filter/text/cql_2/conformance/ConformanceTest42OnlineTest.java
@@ -17,16 +17,9 @@
 
 package org.geotools.filter.text.cql_2.conformance;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import org.geootols.filter.text.cql_2.CQL2;
-import org.geotools.api.data.DataStore;
-import org.geotools.api.filter.Filter;
 import org.geotools.filter.text.cql2.CQLException;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -37,12 +30,8 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class ConformanceTest42OnlineTest extends ATSOnlineTest {
 
-    protected final String criteria;
-    protected final int expectedFeatures;
-
-    public ConformanceTest42OnlineTest(String criteria, int expectedFeatures) {
-        this.criteria = criteria;
-        this.expectedFeatures = expectedFeatures;
+    public ConformanceTest42OnlineTest(String criteria, int expectedFeatures) throws CQLException {
+        super("ne_110m_populated_places_simple", criteria, expectedFeatures);
     }
 
     @Parameterized.Parameters(name = "{index} {0} {1}")
@@ -131,18 +120,5 @@ public class ConformanceTest42OnlineTest extends ATSOnlineTest {
                         0
                     }
                 });
-    }
-
-    public @Test void testConformance() throws CQLException, IOException {
-        DataStore ds = naturalEarthData();
-        int feat = featuresReturned(ds);
-        ds.dispose();
-
-        assertEquals(this.expectedFeatures, feat);
-    }
-
-    protected int featuresReturned(DataStore ds) throws CQLException, IOException {
-        Filter filter = CQL2.toFilter(this.criteria);
-        return ds.getFeatureSource("ne_110m_populated_places_simple").getFeatures(filter).size();
     }
 }

--- a/modules/unsupported/cql2-text/src/test/java/org/geotools/filter/text/cql_2/conformance/ConformanceTest49OnlineTest.java
+++ b/modules/unsupported/cql2-text/src/test/java/org/geotools/filter/text/cql_2/conformance/ConformanceTest49OnlineTest.java
@@ -17,16 +17,9 @@
 
 package org.geotools.filter.text.cql_2.conformance;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import org.geootols.filter.text.cql_2.CQL2;
-import org.geotools.api.data.DataStore;
-import org.geotools.api.filter.Filter;
 import org.geotools.filter.text.cql2.CQLException;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -37,14 +30,9 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class ConformanceTest49OnlineTest extends ATSOnlineTest {
 
-    protected final String dataset;
-    protected final String criteria;
-    protected final int expectedFeatures;
-
-    public ConformanceTest49OnlineTest(String dataset, String criteria, int expectedFeatures) {
-        this.dataset = dataset;
-        this.criteria = criteria;
-        this.expectedFeatures = expectedFeatures;
+    public ConformanceTest49OnlineTest(String dataset, String criteria, int expectedFeatures)
+            throws CQLException {
+        super(dataset, criteria, expectedFeatures);
     }
 
     @Parameterized.Parameters(name = "{index} {0} {1}")
@@ -345,18 +333,5 @@ public class ConformanceTest49OnlineTest extends ATSOnlineTest {
                         1
                     }
                 });
-    }
-
-    public @Test void testConformance() throws CQLException, IOException {
-        DataStore ds = naturalEarthData();
-        int feat = featuresReturned(ds);
-        ds.dispose();
-
-        assertEquals(this.expectedFeatures, feat);
-    }
-
-    protected int featuresReturned(DataStore ds) throws CQLException, IOException {
-        Filter filter = CQL2.toFilter(this.criteria);
-        return ds.getFeatureSource(this.dataset).getFeatures(filter).size();
     }
 }

--- a/modules/unsupported/cql2-text/src/test/java/org/geotools/filter/text/cql_2/conformance/ConformanceTest53OnlineTest.java
+++ b/modules/unsupported/cql2-text/src/test/java/org/geotools/filter/text/cql_2/conformance/ConformanceTest53OnlineTest.java
@@ -17,16 +17,9 @@
 
 package org.geotools.filter.text.cql_2.conformance;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import org.geootols.filter.text.cql_2.CQL2;
-import org.geotools.api.data.DataStore;
-import org.geotools.api.filter.Filter;
 import org.geotools.filter.text.cql2.CQLException;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -37,12 +30,8 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class ConformanceTest53OnlineTest extends ATSOnlineTest {
 
-    protected final String criteria;
-    protected final int expectedFeatures;
-
-    public ConformanceTest53OnlineTest(String criteria, int expectedFeatures) {
-        this.criteria = criteria;
-        this.expectedFeatures = expectedFeatures;
+    public ConformanceTest53OnlineTest(String criteria, int expectedFeatures) throws CQLException {
+        super("ne_110m_populated_places_simple", criteria, expectedFeatures);
     }
 
     @Parameterized.Parameters(name = "{index} {0} {1}")
@@ -69,18 +58,5 @@ public class ConformanceTest53OnlineTest extends ATSOnlineTest {
                     },
                     {"1038280+8=pop_other", 1}
                 });
-    }
-
-    public @Test void testConformance() throws CQLException, IOException {
-        DataStore ds = naturalEarthData();
-        int feat = featuresReturned(ds);
-        ds.dispose();
-
-        assertEquals(this.expectedFeatures, feat);
-    }
-
-    protected int featuresReturned(DataStore ds) throws CQLException, IOException {
-        Filter filter = CQL2.toFilter(this.criteria);
-        return ds.getFeatureSource("ne_110m_populated_places_simple").getFeatures(filter).size();
     }
 }

--- a/modules/unsupported/cql2-text/src/test/java/org/geotools/filter/text/cql_2/conformance/ConformanceTest8OnlineTest.java
+++ b/modules/unsupported/cql2-text/src/test/java/org/geotools/filter/text/cql_2/conformance/ConformanceTest8OnlineTest.java
@@ -17,16 +17,9 @@
 
 package org.geotools.filter.text.cql_2.conformance;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import org.geootols.filter.text.cql_2.CQL2;
-import org.geotools.api.data.DataStore;
-import org.geotools.api.filter.Filter;
 import org.geotools.filter.text.cql2.CQLException;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -37,14 +30,9 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class ConformanceTest8OnlineTest extends ATSOnlineTest {
 
-    protected final String dataset;
-    protected final String criteria;
-    protected final int expectedFeatures;
-
-    public ConformanceTest8OnlineTest(String dataset, String criteria, int expectedFeatures) {
-        this.dataset = dataset;
-        this.criteria = criteria;
-        this.expectedFeatures = expectedFeatures;
+    public ConformanceTest8OnlineTest(String dataset, String criteria, int expectedFeatures)
+            throws CQLException {
+        super(dataset, criteria, expectedFeatures);
     }
 
     @Parameterized.Parameters(name = "{index} {0} {1}")
@@ -127,18 +115,5 @@ public class ConformanceTest8OnlineTest extends ATSOnlineTest {
                     {"ne_110m_populated_places_simple", "boolean=true", 2},
                     {"ne_110m_populated_places_simple", "boolean=false", 1}
                 });
-    }
-
-    public @Test void testConformance() throws CQLException, IOException {
-        DataStore ds = naturalEarthData();
-        int feat = featuresReturned(ds);
-        ds.dispose();
-
-        assertEquals(this.expectedFeatures, feat);
-    }
-
-    protected int featuresReturned(DataStore ds) throws CQLException, IOException {
-        Filter filter = CQL2.toFilter(this.criteria);
-        return ds.getFeatureSource(this.dataset).getFeatures(filter).size();
     }
 }

--- a/modules/unsupported/cql2-text/src/test/java/org/geotools/filter/text/cql_2/conformance/ConformanceTest9OnlineTest.java
+++ b/modules/unsupported/cql2-text/src/test/java/org/geotools/filter/text/cql_2/conformance/ConformanceTest9OnlineTest.java
@@ -17,16 +17,11 @@
 
 package org.geotools.filter.text.cql_2.conformance;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import org.geootols.filter.text.cql_2.CQL2;
-import org.geotools.api.data.DataStore;
 import org.geotools.api.filter.Filter;
 import org.geotools.filter.text.cql2.CQLException;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -37,19 +32,18 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class ConformanceTest9OnlineTest extends ATSOnlineTest {
 
-    protected final String p1;
-    protected final String p2;
-    protected final String p3;
-    protected final String p4;
-    protected final int expectedFeatures;
-
     public ConformanceTest9OnlineTest(
-            String p1, String p2, String p3, String p4, int expectedFeatures) {
-        this.p1 = p1;
-        this.p2 = p2;
-        this.p3 = p3;
-        this.p4 = p4;
-        this.expectedFeatures = expectedFeatures;
+            String p1, String p2, String p3, String p4, int expectedFeatures) throws CQLException {
+        super("ne_110m_populated_places_simple", toFilter(p1, p2, p3, p4), expectedFeatures);
+    }
+
+    protected ConformanceTest9OnlineTest(Filter filter, int expectedFeatures) throws CQLException {
+        super("ne_110m_populated_places_simple", filter, expectedFeatures);
+    }
+
+    private static Filter toFilter(String p1, String p2, String p3, String p4) throws CQLException {
+        String template = "(NOT (%s) AND %s) OR (%s and %s) or not (%s OR %s)";
+        return CQL2.toFilter(String.format(template, p2, p1, p3, p4, p1, p4));
     }
 
     @Parameterized.Parameters(name = "{index} {0} {1} {2} {3}")
@@ -584,23 +578,5 @@ public class ConformanceTest9OnlineTest extends ATSOnlineTest {
                         44
                     }
                 });
-    }
-
-    public @Test void testConformance() throws IOException, CQLException {
-        DataStore ds = naturalEarthData();
-        int feat = featuresReturned(ds);
-        ds.dispose();
-
-        assertEquals(this.expectedFeatures, feat);
-    }
-
-    protected int featuresReturned(DataStore ds) throws CQLException, IOException {
-        Filter filter =
-                CQL2.toFilter(
-                        String.format(
-                                "(NOT (%s) AND %s) OR (%s and %s) or not (%s OR %s)",
-                                p2, p1, p3, p4, p1, p4));
-
-        return ds.getFeatureSource("ne_110m_populated_places_simple").getFeatures(filter).size();
     }
 }


### PR DESCRIPTION
Two changes:

* In library/jdbc, create a Query hint that allows for 3-way filter evaluation in the database (makes sure the various ``property IS NOT NULL`` are not added to the filter before SQL encoding)
* For the ATS implementation, I've centralized the test method in the base class, so that it did not have to be repeated in all subclasses (one place where the hints need to be added, less code duplication), and allowed subclasses to provide either a string or a Filter as the filtering argument. Also allowed custom parsing from text to filter, so that the JSON classes can do their own parsing.